### PR TITLE
docs: Switch moderation logic to Completions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-# github-comment-moderation
+# GitHub Content Moderator Action
+
+## Overview
+
+This GitHub Action moderates the content of issues, pull requests, discussions, and comments using a general-purpose language model via the OpenAI Completions API. It uses a configurable prompt to instruct the model to judge the content and return a structured JSON response. If the model flags the content as inappropriate, the action will hide it.
+
+This repository contains the requirement definitions for a coding agent to implement this GitHub Action.
+
+## Usage
+
+Here is an example of how to use this action in your workflow:
+
+```yaml
+name: Moderate Content
+
+on:
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+  pull_request_review_comment:
+    types: [created, edited]
+  discussion:
+    types: [created, edited]
+  discussion_comment:
+    types: [created, edited]
+
+jobs:
+  moderate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Moderate content
+        uses: {your-username}/{this-repo-name}@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          text-to-moderate: ${{ github.event.issue.body || github.event.pull_request.body || github.event.comment.body || github.event.discussion.body }}
+
+          # Optional: Customize the model and prompt
+          # model: 'gpt-4'
+          # prompt: |
+          #   You are a community moderator. Analyze the following text for policy violations.
+          #   Respond ONLY with a JSON object with "is_inappropriate": boolean and "reason": "your_reason".
+          #   Text: ---
+          #   {{TEXT_TO_MODERATE}}
+          #   ---
+```

--- a/docs/action_interface.md
+++ b/docs/action_interface.md
@@ -1,0 +1,64 @@
+# Action Interface (action.yml)
+
+This document defines the interface for the GitHub Action, which will be specified in the `action.yml` file.
+
+## Inputs
+
+### `github-token`
+
+- **Description**: The GitHub token used to authenticate with the GitHub API. This is required to hide content.
+- **Required**: `true`
+- **Default**: `${{ github.token }}`
+
+### `openai-api-key`
+
+- **Description**: The API key for the OpenAI or compatible service.
+- **Required**: `true`
+
+### `text-to-moderate`
+
+- **Description**: The text content to be moderated.
+- **Required**: `true`
+- **Example**: `${{ github.event.issue.body || github.event.pull_request.body || github.event.comment.body || github.event.discussion.body }}`
+
+### `openai-api-base-url`
+
+- **Description**: The base URL for the OpenAI compatible API. Can be used to connect to any service that exposes an OpenAI-like API.
+- **Required**: `false`
+- **Default**: `https://api.openai.com/v1`
+
+### `model`
+
+- **Description**: The name of the language model to use for moderation.
+- **Required**: `false`
+- **Default**: `gpt-3.5-turbo`
+
+### `temperature`
+
+- **Description**: The temperature setting for the language model, controlling the randomness of the output.
+- **Required**: `false`
+- **Default**: `0.7`
+
+### `prompt`
+
+- **Description**: A custom prompt to instruct the language model on how to perform the moderation. It must instruct the model to return a JSON object.
+- **Required**: `false`
+- **Default**: See `functional_requirements.md` for the default prompt text.
+
+## Outputs
+
+### `is-inappropriate`
+
+- **Description**: A boolean value (`'true'` or `'false'`) indicating whether the language model judged the content as inappropriate.
+
+### `reason`
+
+- **Description**: The reason provided by the language model for its judgment.
+
+### `category`
+
+- **Description**: The category of the violation as determined by the language model.
+
+### `llm-response-json`
+
+- **Description**: The full JSON object returned by the language model for logging and debugging purposes.

--- a/docs/functional_requirements.md
+++ b/docs/functional_requirements.md
@@ -1,0 +1,71 @@
+# Functional Requirements
+
+This document outlines the functional requirements for the GitHub Content Moderator Action.
+
+## 1. Content Moderation Scope
+
+The action must be able to moderate the text content from the following GitHub events:
+- Issues (`issues` event: `opened`, `edited` types)
+- Pull Requests (`pull_request` event: `opened`, `edited` types)
+- Issue Comments (`issue_comment` event: `created`, `edited` types)
+- Pull Request Comments (`pull_request_review_comment` event: `created`, `edited` types)
+- Discussions (`discussion` event: `created`, `edited` types)
+- Discussion Comments (`discussion_comment` event: `created`, `edited` types)
+
+The text to be moderated will be passed via the `text-to-moderate` input.
+
+## 2. Integration with OpenAI Completions API
+
+- The action must make a POST request to the Chat Completions API endpoint (e.g., `/chat/completions`) of the service specified by the `openai-api-base-url` input.
+- The request must use the `openai-api-key` for authentication.
+- The `model` and `temperature` inputs must be passed to the API.
+- The prompt sent to the model will be constructed using the `text-to-moderate` input and the prompt template provided in the `prompt` input.
+
+### 2.1. Default Prompt
+
+If the user does not provide a custom `prompt`, the following default prompt must be used. This prompt is designed to instruct the model to act as a content moderator and return a structured JSON response.
+
+```
+You are a content moderator for a GitHub repository. Your task is to analyze the following text and determine if it violates our content policies. You must respond ONLY with a single, valid JSON object. Do not add any text before or after the JSON object.
+
+The JSON object must have the following structure:
+{
+  "is_inappropriate": boolean,
+  "reason": "A brief explanation of your decision.",
+  "category": "one_of [hate_speech, personal_attack, spam, other]"
+}
+
+If the text is appropriate, set "is_inappropriate" to false and provide a neutral reason. If it is inappropriate, set "is_inappropriate" to true and provide the reason and category.
+
+Here is the text to analyze:
+---
+{{TEXT_TO_MODERATE}}
+---
+```
+
+The coding agent is responsible for replacing `{{TEXT_TO_MODERATE}}` with the actual text content.
+
+## 3. Inappropriate Content Detection Logic
+
+- The action must parse the response from the language model.
+- **JSON Reliability**: The action must be robust against cases where the LLM does not return a valid JSON object. It should implement the following:
+  - Trim any leading/trailing whitespace or markdown code fences (```json ... ```) from the response.
+  - Attempt to parse the cleaned string as JSON.
+  - If parsing fails, the action should retry the API call at least once.
+  - If retries fail, the action should gracefully fail with a clear error message and set the `is-inappropriate` output to `false` to avoid incorrect moderation.
+- If a valid JSON object is parsed, the action will consider the content "inappropriate" if the `is_inappropriate` field in the JSON is `true`.
+- The outputs (`is-inappropriate`, `reason`, `category`, `llm-response-json`) must be set based on the content of the parsed JSON object.
+
+## 4. Action on Inappropriate Content
+
+- If the `is-inappropriate` output is `'true'`, the action must use the GitHub API to hide the content.
+- The `github-token` input must be used for authentication.
+- The agent is responsible for implementing the correct API calls to hide different types of content (Issues, PRs, Comments, Discussions), as previously specified.
+
+## 5. Error Handling
+
+- The action must gracefully handle potential errors, such as:
+  - Invalid API keys or endpoints.
+  - Network issues when communicating with the LLM API.
+  - Invalid GitHub token or insufficient permissions.
+- In case of an error, the action should fail with a clear and descriptive error message.

--- a/docs/non_functional_requirements.md
+++ b/docs/non_functional_requirements.md
@@ -1,0 +1,44 @@
+# Non-Functional Requirements
+
+This document specifies the non-functional requirements for the GitHub Content Moderator Action.
+
+## 1. Security
+
+- **Secrets Handling**: The `openai-api-key` and `github-token` inputs are sensitive values. They must be handled as secrets within the action. Under no circumstances should these keys be printed to the console logs. The coding agent should ensure that any debugging or error messages do not expose these secrets.
+
+## 2. Technology Stack
+
+- **Programming Language**: The action must be implemented using **TypeScript**.
+- **Dependencies**: The agent must use `npm` for dependency management. All dependencies must be documented in a `package.json` file. The agent should choose well-maintained and reputable libraries for the implementation.
+- **Testing Framework**: **Jest** should be used for writing and running tests.
+
+## 3. Performance
+
+- **Execution Time**: The action should be optimized to complete its execution as quickly as possible to avoid unnecessarily delaying GitHub workflows. API calls to OpenAI and GitHub should be made efficiently.
+
+## 4. Code Quality and Maintainability
+
+- **Style Guide**: The TypeScript code should be formatted using a standard formatter like Prettier. A linter (e.g., ESLint) should be configured to enforce code quality.
+- **Documentation**: The code should be well-commented, especially for complex logic related to API interactions and content hiding procedures.
+- **Structure**: The project should be structured logically, separating concerns where appropriate (e.g., API clients, business logic).
+
+## 5. Testing
+
+### 5.1. Unit Tests
+
+- The coding agent is expected to provide unit tests for the core logic of the action. This includes testing the logic for:
+  - Assembling the final prompt from the template and the input text.
+  - Parsing the language model's response, including handling of invalid or incomplete JSON.
+  - Correctly interpreting the `is_inappropriate` flag from the JSON object.
+- Mocking should be used to simulate API calls to the LLM and GitHub to avoid reliance on external services during testing.
+
+### 5.2. Integration Tests
+
+- The agent must write integration tests to verify the end-to-end workflow of the action.
+- These tests should use sample GitHub event payloads (e.g., a sample `issue.opened` event) as input.
+- The tests must verify that the action correctly:
+  - Parses the input from the event payload.
+  - Calls the (mocked) Completions API with the correctly constructed prompt.
+  - Processes various (mocked) responses from the API, including valid JSON, invalid JSON, and error cases.
+  - Calls the (mocked) GitHub API to hide the content if the moderation decision is `true`.
+  - Sets the correct action outputs based on the LLM's response.


### PR DESCRIPTION
This commit fundamentally changes the core logic of the action from using the specialized OpenAI Moderation API to the general-purpose Completions API. This change resolves the conflict with the main branch by re-applying the new architecture on top of the latest main.

This change is reflected across all requirement documents:
- `docs/action_interface.md`: Inputs have been updated to remove thresholds and add parameters for the Completions API (`model`, `prompt`, `temperature`, `openai-api-base-url`). Outputs are now based on the expected JSON response from the LLM.
- `docs/functional_requirements.md`: The API integration section has been rewritten. It now includes a default prompt and specifies a robust strategy for handling potentially invalid JSON responses from the LLM, including retries and fallbacks.
- `README.md`: The overview and usage examples have been updated to reflect the new API and its configuration.
- `docs/non_functional_requirements.md`: Testing requirements have been updated to cover prompt assembly and robust JSON parsing logic.